### PR TITLE
refactor: management.base.TelegramCommand is not BaseTelegramCommand

### DIFF
--- a/django_telegram_app/management/base.py
+++ b/django_telegram_app/management/base.py
@@ -13,7 +13,7 @@ from django_telegram_app.conf import settings as app_settings
 from django_telegram_app.resolver import get_telegram_settings_model
 
 
-class TelegramCommand(BaseCommand):
+class BaseTelegramCommand(BaseCommand):
     """Base command class to start Telegram bot commands."""
 
     command_text: str = ""

--- a/docs/03-management-commands.md
+++ b/docs/03-management-commands.md
@@ -1,5 +1,5 @@
 # Writing a custom management command
-Django telegram app provides a base management command (TelegramCommand) to facilitate calling telegram commands using `manage.py`.
+Django telegram app provides a base management command (BaseTelegramCommand) to facilitate calling telegram commands using `manage.py`.
 This command automatically activates (and later deactivates) the user's configured language (fallback to settings.LANGUAGE_CODE).
 Another specificity is that the class provides a should_run function which should return a boolean. This could be useful when the command is configured to run daily using a cronjob, but should not run on specific days.
 
@@ -12,10 +12,10 @@ An example of a custom management command:
 
 from django.utils import timezone
 
-from django_telegram_app.management.base import TelegramCommand
+from django_telegram_app.management.base import BaseTelegramCommand
 
 
-class Command(TelegramCommand):
+class Command(BaseTelegramCommand):
     """Start the customcommand command."""
 
     help = "Start the customcommand command to ask users yes or no."


### PR DESCRIPTION
`TelegramCommand` could cause confusion for users with custom base commands as `TelegramCommand` is the suggested name to use for a Custom BaseCommand. Eventhough this class lives in another package, it could be confusing, so this is now called a `BaseTelegramCommand`