### PR TITLE
refactor: rename TelegramBotTestCase.url to webhook

### DIFF
--- a/django_telegram_app/bot/testing/testcases.py
+++ b/django_telegram_app/bot/testing/testcases.py
@@ -11,10 +11,10 @@ from django_telegram_app.conf import settings
 class TelegramBotTestCase(TestCase):
     """Base test case for Telegram bot tests."""
 
-    @classmethod
-    def setUpTestData(cls):
-        """Set up test data for the testcase."""
-        cls.url = reverse("webhook")
+    @property
+    def webhook_url(self):
+        """Return the webhook URL."""
+        return reverse("webhook")
 
     @classmethod
     def tearDownClass(cls):
@@ -44,7 +44,7 @@ class TelegramBotTestCase(TestCase):
     def post_data(self, data: dict, verify: bool = True):
         """Post data to the webhook."""
         response = self.client.post(
-            self.url,
+            self.webhook_url,
             data=data,
             headers={"X-Telegram-Bot-Api-Secret-Token": settings.WEBHOOK_TOKEN},
             content_type="application/json",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -21,7 +21,6 @@ class BotTests(TelegramBotTestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data."""
-        super().setUpTestData()
         cls.user = get_user_model().objects.create_user(username="dummyuser", password="dummypass")
         cls.telegram_setting = get_telegram_settings_model().objects.create(user=cls.user, chat_id=123456789)
 
@@ -50,7 +49,7 @@ class BotTests(TelegramBotTestCase):
     def test_telegram_invalid_token(self):
         """Test the telegram app with an invalid token."""
         response = self.client.post(
-            self.url,
+            self.webhook_url,
             data={},
             headers={"X-Telegram-Bot-Api-Secret-Token": "invalid_token"},
             content_type="application/json",
@@ -152,7 +151,7 @@ class BotTests(TelegramBotTestCase):
         """Test that any token is valid if BOT_API_SECRET_TOKEN is not configured."""
         with patch("django_telegram_app.bot.bot.settings.WEBHOOK_TOKEN", ""):
             response = self.client.post(
-                self.url,
+                self.webhook_url,
                 data={},
                 headers={"X-Telegram-Bot-Api-Secret-Token": "any_token"},
                 content_type="application/json",


### PR DESCRIPTION
It's also a property now and the TelegramBotTestCase no longer overrides setUpTestData. This is to make it more user-friendly, as before this change whenever test-case would subclass TelegramBotTestCase.setUpTestData it should call super. If it failed to do so, self.url would not be available.